### PR TITLE
Add and update GD32_F307VG

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4465,18 +4465,21 @@
         "public": false,
         "extra_labels": ["Gigadevice"],
         "supported_toolchains": ["ARM", "IAR", "GCC_ARM"],
-        "device_has":["USTICKER", "LPTICKER", "CRC", "ANALOGIN", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL"]
+        "device_has":["USTICKER", "CRC", "ANALOGIN", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL"]
     },
     "GD32_F307VG": {
         "inherits": ["GD32_Target"],
         "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M4",
-        "extra_labels_add": ["GD32F30X"],
+        "extra_labels_add": ["GD32F30X", "GD32F307VG", "GD_EMAC"],
         "detect_code": ["1701"],
-        "macros_add": ["CMSIS_VECTAB_VIRTUAL", "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""],
-        "device_has_add": ["RTC", "I2C", "I2CSLAVE", "ANALOGOUT", "SPI", "SPISLAVE", "ETHERNET"],
+        "macros_add": ["GD32F30X_CL"],
+        "device_has_add": ["RTC", "I2C", "CAN", "I2CSLAVE", "ANALOGOUT", "SPI", "SPISLAVE", "SERIAL_ASYNCH", "SERIAL_FC", "EMAC"],
         "default_lib": "small",
         "release_versions": ["2", "5"],
-        "device_name": "GD32F307VG"
+        "device_name": "GD32F307VG",
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     }
 }


### PR DESCRIPTION
modify the information about GD32_F307VG

### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
    GD32_F307VG does not support LPTICKER, and CMSIS_VECTAB_VIRTUAL&CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\ are not used. Add CAN/EMAC support.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

